### PR TITLE
replaced deprecated connection parameter

### DIFF
--- a/airflow_registry/utils/slack_notifications.py
+++ b/airflow_registry/utils/slack_notifications.py
@@ -26,7 +26,7 @@ def base_failure_alert(context, conn):
 
     failed_alert = SlackWebhookOperator(
         task_id='slack_failure_alert',
-        http_conn_id=conn,
+        slack_webhook_conn_id=conn,
         message=slack_msg)
     return failed_alert.execute(context=context)
 


### PR DESCRIPTION
* Slack Incoming Webhook connection id parameter has been deprecated and `http_conn_id` is replace by `slack_webhook_conn_id`.

Ref updated code : https://github.com/apache/airflow/blob/main/airflow/providers/slack/hooks/slack_webhook.py


![image](https://github.com/patterninc/airflow_registry/assets/115449585/e9759c43-8214-4cb1-9831-5ecb052764a4)
